### PR TITLE
enable token authentication

### DIFF
--- a/wurstfabrik/settings.py
+++ b/wurstfabrik/settings.py
@@ -26,6 +26,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'rest_framework.authtoken',
     'wurst'
 ]
 
@@ -79,6 +80,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
     ),
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.NamespaceVersioning',
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',  # TODO: This shouldn't be necessary, but some tests fail w/ multipart!

--- a/wurstfabrik/urls.py
+++ b/wurstfabrik/urls.py
@@ -1,10 +1,12 @@
 from django.conf.urls import include, url
 from django.contrib import admin
 
+from rest_framework.authtoken.views import obtain_auth_token
+
 from wurst.api.router import get_router
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^api/v1/', include(get_router().urls, namespace='v1')),
-
+    url(r'^api/v1/tokens/', obtain_auth_token),
 ]


### PR DESCRIPTION
`POST` `{"username":"foouser","password":"secret"}` or the equivalent form to `/api/v1/tokens/` to get `{"token": "9c158ea8132b23e823c945e37dcc63fcbd1977df"}`.

Apply this to any API view as `Authorization: Token 9c158ea8132b23e823c945e37dcc63fcbd1977df` for L. Dallas multipass.
## Possible future improvements
- `DELETE` on `/api/v1/tokens/9c158ea8132b23e823c945e37dcc63fcbd1977df` to revoke a token
- [The default implementation](https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/authtoken/views.py) of `obtain_auth_token` currently returns the same token when `POST`ed again. We may want to allow different tokens for different devices.
- `GET` on `/api/v1/tokens/` to query currently active tokens.
